### PR TITLE
Add Swagger UI endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The `httpc` package is a Gin-based HTTP server and client for Go applications, p
 - **Complex JSON Support**: Handles nested JSON payloads with strict validation using `github.com/go-playground/validator/v10@v10.26.0`, enforcing required fields, length constraints, and custom rules.
 - **Healthcheck**: `/health` endpoint returning `200 OK` with `{"status":"healthy"}`.
 - **Swagger Documentation**: Generates OpenAPI 3.0.3 JSON at `/api/docs/swagger.json` for registered endpoints, reflecting service methods and schemas.
+- **Swagger UI**: Provides an interactive UI at `/api/docs/index.html` that dynamically loads the generated Swagger JSON.
 - **Mandatory Integration**: Uses `config` for settings and `logger` for request logging with structured JSON output.
 - **Optional Tracing**: Supports `go.opentelemetry.io/otel@v1.24.0` for request tracing when enabled, for both server and client.
 - **Graceful Shutdown**: Supports graceful server shutdown via `Shutdown` method, handling active connections with a configurable timeout.
@@ -284,7 +285,7 @@ curl http://localhost:8080/health
 ```
 
 ### OpenAPI Documentation
-Access the OpenAPI 3.0.3 JSON at `http://localhost:8080/api/docs/swagger.json` to explore the API. The dynamically generated documentation reflects service methods, schemas, and validation rules.
+Access the OpenAPI 3.0.3 JSON at `http://localhost:8080/api/docs/swagger.json` to explore the API or visit `http://localhost:8080/api/docs/index.html` for the Swagger UI. The dynamically generated documentation reflects service methods, schemas, and validation rules.
 
 Example:
 ```bash

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -2,6 +2,7 @@ package httpc
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -88,5 +89,18 @@ func TestSwagger(t *testing.T) {
 		require.True(t, ok)
 		require.Contains(t, properties, "name")
 		require.Contains(t, properties, "email")
+	})
+
+	t.Run("Swagger UI Endpoint", func(t *testing.T) {
+		svc := &TestService{}
+		ts := setupServer(t, serverCfg, svc, "/v1")
+		defer ts.Close()
+
+		resp, err := http.Get(ts.URL + "/api/docs/index.html")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "Swagger UI")
 	})
 }


### PR DESCRIPTION
## Summary
- serve Swagger UI at `/api/docs/index.html`
- include patch, options and head HTTP methods
- test the Swagger UI endpoint
- document new route in README

## Testing
- `for pkg in $(go list ./...); do if [[ $pkg != */examples* ]]; then go test $pkg; fi; done`